### PR TITLE
continue with setup; add env var-based trace options

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,16 @@
+# shellcheck shell=bash
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+fi
+
+dotenv_if_exists
+
+# watch_file "$(find ./nix -name "*.nix" -type f)"
+
+OS_AND_SYSTEM=$(uname -a)
+
+if [[ "${NO_NIX:-}" == "1" || $OS_AND_SYSTEM == "Darwin"* ]]; then
+  source non-nix-build/env.sh
+else
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ spec/target
 **/fuzz/artifacts/
 **/fuzz/crash-inputs/
 **/fuzz/Cargo.lock
+
+*.wasm
+.direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,10 +1713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-test"
-version = "0.44.0"
-
-[[package]]
 name = "wasmi"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [
     "crates/ir",
     "crates/fuzz",
     "crates/wast",
-    "fuzz", "wasm-test", "crates/tracer",
+    "fuzz", "crates/tracer",
+    # "wasm-test",
 ]
 exclude = []
 resolver = "2"

--- a/crates/tracer/src/lib.rs
+++ b/crates/tracer/src/lib.rs
@@ -1,10 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::println;
 
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
 // TODO
 #[derive(Debug, Clone)]
 struct DebugInfo {
@@ -25,7 +21,10 @@ impl DebugInfo {
 
 #[derive(Debug, Clone)]
 pub struct WasmTracer {
+    pub tracing: bool,
     debug_info: DebugInfo,
+    info: Vec<String>,
+    index: usize,
     // TODO: tracer: runtime_tracing.Tracer,
     // etc
 }
@@ -33,10 +32,17 @@ pub struct WasmTracer {
 // just to make it build so we can branch-out
 
 impl WasmTracer {
-    pub fn new(wasm_exe_path: &Path) -> Self {
+    pub fn new(tracing: bool, wasm_exe_path: &Path) -> Self {
         WasmTracer {
+            tracing,
             debug_info: DebugInfo::new(wasm_exe_path),
+            info: vec![],
+            index: 0,
         }
+    }
+
+    pub fn no_tracing() -> Self {
+        Self::new(false, &Path::new(""))
     }
 
     pub fn load_local_variables(&mut self, address: usize) { // -> ???
@@ -49,7 +55,10 @@ impl WasmTracer {
         if !cached {
             // TODO etc
             // load debuginfo etc
+            self.info.push(format!("{}", self.index));
+            self.index += 1;
         }
+        println!("{:?}", self.info);
     }
 }
 
@@ -68,7 +77,5 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
     }
 }

--- a/crates/tracer/src/lib.rs
+++ b/crates/tracer/src/lib.rs
@@ -46,7 +46,7 @@ impl WasmTracer {
     }
 
     pub fn load_local_variables(&mut self, address: usize) { // -> ???
-        println!("load_local_variables {address}");
+        // println!("load_local_variables {address}");
         // e.g. here we might call something like
         // some kind of check if we already have the info for the current context
         // let cached = TODO;
@@ -58,7 +58,7 @@ impl WasmTracer {
             self.info.push(format!("{}", self.index));
             self.index += 1;
         }
-        println!("{:?}", self.info);
+        // println!("{:?}", self.info);
     }
 }
 

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -140,7 +140,7 @@ impl<'engine> Executor<'engine> {
                 // TODO: good way to take address
                 //let address = usize::from(self.ip.get());
                 let address = 0x000000010; // should be in the main subprogram >= low_pc
-                //std::println!("address of {:?}: {:?}", *self.ip.get(), address);
+                std::println!("address of {:?}: TODO", *self.ip.get());
                 // TODO: make this be a field with correct lifetime
                 tracer.load_local_variables(address);
 

--- a/crates/wasmi/src/engine/executor/instrs.rs
+++ b/crates/wasmi/src/engine/executor/instrs.rs
@@ -129,24 +129,29 @@ impl<'engine> Executor<'engine> {
     #[inline(always)]
     fn execute<T>(mut self, store: &mut Store<T>) -> Result<(), Error> {
         use Instruction as Instr;
+        let tracing = std::env::var("CODETRACER_WASMI_TRACING").unwrap_or(std::string::String::from("")) == "1";
+        let env_wasm_path = std::env::var("CODETRACER_WASM_PATH").unwrap_or(std::string::String::from(""));
+        let wasm_path = std::path::Path::new(&env_wasm_path);
+        let mut tracer = WasmTracer::new(tracing, &wasm_path);
         loop {
-            // TODO: change that, just startting from somewehre
-            // Args: path : Path, instruction address(?) , step?
-            // TODO: good way to take address
-            //let address = usize::from(self.ip.get());
-            let address = 0x000000010; // should be in the main subprogram >= low_pc
-            //std::println!("address of {:?}: {:?}", *self.ip.get(), address);
-            // TODO: make this be a field with correct lifetime
-            let mut tracer = WasmTracer::new(std::path::Path::new("/home/pesho/code/codetracer-wasmi-recorder/wasm_test.wasm")); // "<path to test.wasm>: for now hardcoded TODO pass");
-            tracer.load_local_variables(address);
+            if tracer.tracing {
+                // TODO: change that, just startting from somewehre
+                // Args: path : Path, instruction address(?) , step?
+                // TODO: good way to take address
+                //let address = usize::from(self.ip.get());
+                let address = 0x000000010; // should be in the main subprogram >= low_pc
+                //std::println!("address of {:?}: {:?}", *self.ip.get(), address);
+                // TODO: make this be a field with correct lifetime
+                tracer.load_local_variables(address);
 
-            // load debuginfo from gimli <- for this ip;
-            // -> find out current scope and vars in it:
-            //   some kind of mapping between them and locations
-            // -> load them with some general(for us) mechanism from wasmi's memory(?)
-            // e.g. load_expression(expr, location, ..) -> ValueRecord
-            // (to be iterated on, just an idea)
-            match *self.ip.get() {
+                // load debuginfo from gimli <- for this ip;
+                // -> find out current scope and vars in it:
+                //   some kind of mapping between them and locations
+                // -> load them with some general(for us) mechanism from wasmi's memory(?)
+                // e.g. load_expression(expr, location, ..) -> ValueRecord
+                // (to be iterated on, just an idea)
+            }
+                match *self.ip.get() {
                 Instr::Trap { trap_code } => self.execute_trap(trap_code)?,
                 Instr::ConsumeFuel { block_fuel } => {
                     self.execute_consume_fuel(&mut store.inner, block_fuel)?

--- a/justfile
+++ b/justfile
@@ -8,3 +8,6 @@ dwarfdump wasm-path:
 dis wasm-path:
   # from binaryen
   wasm-dis {{wasm-path}}
+
+trace wasm-path:
+  env CODETRACER_WASMI_TRACING=1 CODETRACER_WASM_PATH=$(realpath {{wasm-path}}) target/debug/wasmi_cli wasm_test.wasm

--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+build-wasm-test-c:
+  emcc -O0 -g3 -o wasm_test.wasm wasm_test.c
+
+dwarfdump wasm-path:
+  # from llvm
+  llvm-dwarfdump {{wasm-path}}
+
+dis wasm-path:
+  # from binaryen
+  wasm-dis {{wasm-path}}

--- a/shell.nix
+++ b/shell.nix
@@ -26,7 +26,15 @@ mkShell {
     emscripten
     binaryen
     llvm
+    just
     rust-analyzer
+
+    figlet
   ];
 
+  shellHook = ''
+    export EM_CACHE=/tmp/emcc/
+
+    figlet "welcome to wasmi recorder"
+  '';
 }

--- a/wasm_test.c
+++ b/wasm_test.c
@@ -1,0 +1,4 @@
+int main() {
+    int x = 1;
+    int y = 2;
+}

--- a/wasm_test.c
+++ b/wasm_test.c
@@ -1,4 +1,4 @@
 int main() {
     int x = 1;
-    int y = 2;
+    int y = 2 + x;
 }


### PR DESCRIPTION
*  tooling: (code from yesterday); add the just command runner/justfile, some scripts, .envrc, small setup cleanups (originally in #1 ) 
* add env var-based trace options: looks simpler than adding CLI params (alternative to #2 )

we need to pass cli params through many layers/calls: done in another branch: in PR https://github.com/metacraft-labs/codetracer-wasmi-recorder/pull/2 and the patch is too big; also we can just keep tracer local, instead of passing it everywhere