### PR TITLE
ci: trust and populate Attic cache

### DIFF
--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -26,3 +26,123 @@ runs:
 
         clone_sibling codetracer-trace-format
         clone_sibling codetracer-trace-format-nim
+
+    - name: Install trace-format build tools (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        apt_updated=0
+        apt_install() {
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::apt-get is required to install $* on this Linux runner"
+            exit 1
+          fi
+          if [ "${apt_updated}" -eq 0 ]; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update
+            else
+              apt-get update
+            fi
+            apt_updated=1
+          fi
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get install -y "$@"
+          else
+            apt-get install -y "$@"
+          fi
+        }
+
+        nim_version=2.2.10
+
+        if ! command -v curl >/dev/null 2>&1; then
+          case "${RUNNER_OS}" in
+            Linux) apt_install curl ca-certificates ;;
+            macOS)
+              echo "::error::curl is required to install Nim on macOS"
+              exit 1
+              ;;
+          esac
+        fi
+
+        if ! command -v nim >/dev/null 2>&1 || ! nim --version | grep -q "Version ${nim_version}"; then
+          export CHOOSENIM_CHOOSE_VERSION="${nim_version}"
+          curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+        fi
+
+        echo "${HOME}/.nimble/bin" >> "${GITHUB_PATH}"
+        export PATH="${HOME}/.nimble/bin:${PATH}"
+
+        if ! command -v capnp >/dev/null 2>&1; then
+          case "${RUNNER_OS}" in
+            Linux)
+              apt_install capnproto
+              ;;
+            macOS)
+              if command -v nix >/dev/null 2>&1; then
+                capnp_path="$(nix build --no-link --print-out-paths nixpkgs#capnproto)/bin"
+                echo "${capnp_path}" >> "${GITHUB_PATH}"
+                export PATH="${capnp_path}:${PATH}"
+              elif command -v brew >/dev/null 2>&1; then
+                brew install capnp
+              else
+                echo "::error::capnp is required, but this macOS runner has neither nix nor brew"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::unsupported Unix runner OS: ${RUNNER_OS}"
+              exit 1
+              ;;
+          esac
+        fi
+
+        nim --version
+        nimble --version
+        capnp --version
+
+    - name: Install trace-format build tools (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+
+        $nimVersion = "2.2.10"
+        $needsNim = -not (Get-Command nim.exe -ErrorAction SilentlyContinue)
+        if (-not $needsNim) {
+          $needsNim = -not ((nim --version) -match "Version $nimVersion")
+        }
+
+        if ($needsNim) {
+          $nimRoot = Join-Path $env:RUNNER_TEMP "nim-$nimVersion-$env:GITHUB_RUN_ID"
+          $nimZip = Join-Path $env:RUNNER_TEMP "nim-$nimVersion.zip"
+          Invoke-WebRequest "https://nim-lang.org/download/nim-$($nimVersion)_x64.zip" -OutFile $nimZip
+          New-Item -ItemType Directory -Path $nimRoot | Out-Null
+          Expand-Archive $nimZip -DestinationPath $nimRoot -Force
+          $nimExe = Get-ChildItem $nimRoot -Recurse -Filter nim.exe |
+            Where-Object { $_.Directory.Name -eq "bin" } |
+            Select-Object -First 1
+          if (-not $nimExe) {
+            throw "Could not find nim.exe after extracting $nimZip"
+          }
+          $nimBin = $nimExe.Directory.FullName
+          Add-Content $env:GITHUB_PATH $nimBin
+          $env:Path = "$nimBin;$env:Path"
+        }
+
+        $nimbleBin = Join-Path $env:USERPROFILE ".nimble\bin"
+        Add-Content $env:GITHUB_PATH $nimbleBin
+        $env:Path = "$nimbleBin;$env:Path"
+
+        if (-not (Get-Command capnp.exe -ErrorAction SilentlyContinue)) {
+          if (Get-Command choco.exe -ErrorAction SilentlyContinue) {
+            choco install capnproto -y --no-progress
+          } else {
+            throw "capnp is required, but this Windows runner has neither capnp.exe nor choco.exe on PATH"
+          }
+        }
+
+        nim --version
+        nimble --version
+        capnp --version

--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -54,6 +54,28 @@ runs:
           fi
         }
 
+        ensure_macos_c_compiler() {
+          if [ "${RUNNER_OS}" != "macOS" ] || command -v cc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1; then
+            return
+          fi
+
+          if command -v nix >/dev/null 2>&1; then
+            clang_bin="$(nix build --no-link --print-out-paths nixpkgs#clang)/bin"
+            echo "${clang_bin}" >> "${GITHUB_PATH}"
+            export PATH="${clang_bin}:${PATH}"
+            export CC="${clang_bin}/clang"
+          elif command -v brew >/dev/null 2>&1; then
+            brew install llvm
+            clang_bin="$(brew --prefix llvm)/bin"
+            echo "${clang_bin}" >> "${GITHUB_PATH}"
+            export PATH="${clang_bin}:${PATH}"
+            export CC="${clang_bin}/clang"
+          else
+            echo "::error::choosenim requires a C compiler, but this macOS runner has neither clang, nix, nor brew"
+            exit 1
+          fi
+        }
+
         nim_version=2.2.10
 
         if ! command -v curl >/dev/null 2>&1; then
@@ -65,6 +87,8 @@ runs:
               ;;
           esac
         fi
+
+        ensure_macos_c_compiler
 
         if ! command -v nim >/dev/null 2>&1 || ! nim --version | grep -q "Version ${nim_version}"; then
           export CHOOSENIM_CHOOSE_VERSION="${nim_version}"

--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -1,20 +1,28 @@
-name: Checkout codetracer-trace-format sibling
-description: Clone codetracer-trace-format next to this repository for workspace path dependencies.
+name: Checkout CodeTracer trace-format siblings
+description: Clone CodeTracer trace-format repositories next to this repository for workspace path dependencies.
 runs:
   using: composite
   steps:
-    - name: Clone codetracer-trace-format
+    - name: Clone trace-format siblings
       shell: bash
       run: |
         set -euo pipefail
 
-        remote=https://github.com/metacraft-labs/codetracer-trace-format.git
         trace_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-dev}}"
 
-        if ! git ls-remote --exit-code --heads "$remote" "$trace_ref" >/dev/null 2>&1; then
-          trace_ref=dev
-        fi
+        clone_sibling() {
+          repo="$1"
+          remote="https://github.com/metacraft-labs/${repo}.git"
+          ref="$trace_ref"
 
-        target="${GITHUB_WORKSPACE}/../codetracer-trace-format"
-        rm -rf "$target"
-        git clone --depth 1 --branch "$trace_ref" "$remote" "$target"
+          if ! git ls-remote --exit-code --heads "$remote" "$ref" >/dev/null 2>&1; then
+            ref=dev
+          fi
+
+          target="${GITHUB_WORKSPACE}/../${repo}"
+          rm -rf "$target"
+          git clone --depth 1 --branch "$ref" "$remote" "$target"
+        }
+
+        clone_sibling codetracer-trace-format
+        clone_sibling codetracer-trace-format-nim

--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -1,0 +1,20 @@
+name: Checkout codetracer-trace-format sibling
+description: Clone codetracer-trace-format next to this repository for workspace path dependencies.
+runs:
+  using: composite
+  steps:
+    - name: Clone codetracer-trace-format
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        remote=https://github.com/metacraft-labs/codetracer-trace-format.git
+        trace_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-dev}}"
+
+        if ! git ls-remote --exit-code --heads "$remote" "$trace_ref" >/dev/null 2>&1; then
+          trace_ref=dev
+        fi
+
+        target="${GITHUB_WORKSPACE}/../codetracer-trace-format"
+        rm -rf "$target"
+        git clone --depth 1 --branch "$trace_ref" "$remote" "$target"

--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -33,6 +33,10 @@ runs:
       run: |
         set -euo pipefail
 
+        if [ "${RUNNER_OS}" = "macOS" ]; then
+          export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}"
+        fi
+
         apt_updated=0
         apt_install() {
           if ! command -v apt-get >/dev/null 2>&1; then

--- a/.github/actions/checkout-trace-format/action.yml
+++ b/.github/actions/checkout-trace-format/action.yml
@@ -34,6 +34,10 @@ runs:
         set -euo pipefail
 
         if [ "${RUNNER_OS}" = "macOS" ]; then
+          echo "/usr/bin" >> "${GITHUB_PATH}"
+          echo "/bin" >> "${GITHUB_PATH}"
+          echo "/usr/sbin" >> "${GITHUB_PATH}"
+          echo "/sbin" >> "${GITHUB_PATH}"
           export PATH="/usr/bin:/bin:/usr/sbin:/sbin:${PATH}"
         fi
 
@@ -59,19 +63,31 @@ runs:
         }
 
         ensure_macos_c_compiler() {
-          if [ "${RUNNER_OS}" != "macOS" ] || command -v cc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1; then
+          if [ "${RUNNER_OS}" != "macOS" ]; then
+            return
+          fi
+
+          if command -v cc >/dev/null 2>&1; then
+            echo "CC=$(command -v cc)" >> "${GITHUB_ENV}"
+            return
+          fi
+
+          if command -v clang >/dev/null 2>&1; then
+            echo "CC=$(command -v clang)" >> "${GITHUB_ENV}"
             return
           fi
 
           if command -v nix >/dev/null 2>&1; then
             clang_bin="$(nix build --no-link --print-out-paths nixpkgs#clang)/bin"
             echo "${clang_bin}" >> "${GITHUB_PATH}"
+            echo "CC=${clang_bin}/clang" >> "${GITHUB_ENV}"
             export PATH="${clang_bin}:${PATH}"
             export CC="${clang_bin}/clang"
           elif command -v brew >/dev/null 2>&1; then
             brew install llvm
             clang_bin="$(brew --prefix llvm)/bin"
             echo "${clang_bin}" >> "${GITHUB_PATH}"
+            echo "CC=${clang_bin}/clang" >> "${GITHUB_ENV}"
             export PATH="${clang_bin}:${PATH}"
             export CC="${clang_bin}/clang"
           else

--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -69,6 +69,41 @@ jobs:
           attic-cache: ${{ vars.ATTIC_CACHE }}
           attic-endpoint: ${{ vars.ATTIC_ENDPOINT }}
 
+      - name: Prepare Windows reprobuild runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $clingoDll = Get-ChildItem -LiteralPath $env:RUNNER_TEMP -Filter clingo.dll -Recurse -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if ($null -eq $clingoDll) {
+            throw "clingo.dll not found under $env:RUNNER_TEMP"
+          }
+
+          Add-Content -Path $env:GITHUB_PATH -Value $clingoDll.DirectoryName
+
+          $reproBin = Join-Path $env:GITHUB_WORKSPACE "reprobuild\build\bin"
+          if (Test-Path -LiteralPath $reproBin -PathType Container) {
+            Copy-Item -LiteralPath $clingoDll.FullName -Destination (Join-Path $reproBin "clingo.dll") -Force
+          }
+
+      - name: Prepare macOS reprobuild sandbox tools
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sandbox="${GITHUB_WORKSPACE}/.reprobuild-sandbox-tools"
+          mkdir -p "${sandbox}/bin"
+          if [ -x /opt/homebrew/bin/bash ]; then
+            ln -sf /opt/homebrew/bin/bash "${sandbox}/bin/sh"
+          elif command -v nix >/dev/null 2>&1; then
+            nix_bash="$(nix shell --accept-flake-config nixpkgs#bashInteractive --command bash -lc 'command -v bash')"
+            ln -sf "${nix_bash}" "${sandbox}/bin/sh"
+          else
+            echo "No non-SIP bash available for CT_SANDBOX_TOOLS_DIR" >&2
+            exit 1
+          fi
+          echo "CT_SANDBOX_TOOLS_DIR=${sandbox}" >> "${GITHUB_ENV}"
+
       - name: repro build
         # Builds the conventional `build` collection declared in
         # `repro.nim`. Verifies the primary shipping artefact (the
@@ -79,15 +114,6 @@ jobs:
       - name: repro test
         # Materialises the `test` collection.
         run: dev-exec repro test
-
-      - name: just build (cross-check)
-        # Re-runs the legacy `just build` path inside the same env so
-        # we catch silent divergences between `repro build` outputs
-        # and what the dev shell + Justfile produce today.
-        run: dev-exec just build
-
-      - name: just test (cross-check)
-        run: dev-exec just test
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           env-flavor: reprobuild
           gh-token: ${{ steps.ci_token.outputs.token }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
+          attic-cache: ${{ vars.ATTIC_CACHE }}
+          attic-endpoint: ${{ vars.ATTIC_ENDPOINT }}
 
       - name: repro build
         # Builds the conventional `build` collection declared in

--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -61,6 +61,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: reprobuild
+          repro-build-pin: codex/attic-ci-cache-vars
           gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.SUBSTITUTERS }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}

--- a/.github/workflows/ci-reprobuild.yml
+++ b/.github/workflows/ci-reprobuild.yml
@@ -73,8 +73,59 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          $clingoRoot = Join-Path $env:RUNNER_TEMP "reprobuild-clingo-5.8.0"
           $clingoDll = Get-ChildItem -LiteralPath $env:RUNNER_TEMP -Filter clingo.dll -Recurse -File -ErrorAction SilentlyContinue |
             Select-Object -First 1
+          if ($null -eq $clingoDll) {
+            Remove-Item -LiteralPath $clingoRoot -Recurse -Force -ErrorAction SilentlyContinue
+            New-Item -ItemType Directory -Path $clingoRoot | Out-Null
+            $env:REPROBUILD_CLINGO_ROOT = $clingoRoot
+            python -m pip install --disable-pip-version-check --quiet zstandard==0.23.0
+            @'
+import hashlib
+import io
+import os
+import pathlib
+import tarfile
+import urllib.request
+import zipfile
+
+import zstandard
+
+URL = "https://conda.anaconda.org/conda-forge/win-64/clingo-5.8.0-py312h4128c23_0.conda"
+SHA256 = "9ffe4802f8d39991bef75a1548f10147a59e5549eca65fef5119eb281e4f343a"
+ROOT = pathlib.Path(os.environ["REPROBUILD_CLINGO_ROOT"])
+PKG = ROOT / "clingo.conda"
+
+urllib.request.urlretrieve(URL, PKG)
+actual = hashlib.sha256(PKG.read_bytes()).hexdigest()
+if actual != SHA256:
+    raise SystemExit(f"clingo package sha256 mismatch: {actual} != {SHA256}")
+
+with zipfile.ZipFile(PKG) as archive:
+    pkg_member = next(
+        name for name in archive.namelist()
+        if name.startswith("pkg-") and name.endswith(".tar.zst")
+    )
+    payload = zstandard.ZstdDecompressor().decompress(archive.read(pkg_member))
+
+with tarfile.open(fileobj=io.BytesIO(payload), mode="r:") as tar:
+    for member in tar.getmembers():
+        name = member.name.replace("\\", "/")
+        if not name.startswith("Library/bin/") or member.isdir():
+            continue
+        rel = pathlib.PurePosixPath(name).relative_to("Library")
+        dest = ROOT / pathlib.Path(*rel.parts)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tar.extractfile(member) as src, dest.open("wb") as out:
+            out.write(src.read())
+
+PKG.unlink(missing_ok=True)
+print(f"clingo runtime staged at {ROOT / 'bin'}")
+'@ | python -
+            $clingoDll = Get-ChildItem -LiteralPath $clingoRoot -Filter clingo.dll -Recurse -File -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+          }
           if ($null -eq $clingoDll) {
             throw "clingo.dll not found under $env:RUNNER_TEMP"
           }

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown, x86_64-unknown-none
@@ -83,6 +84,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -107,6 +109,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@1.83.0
       - uses: Swatinem/rust-cache@v2
       - run: >-
@@ -131,6 +134,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
@@ -156,6 +160,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -175,6 +180,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-docs, rust-src
@@ -199,6 +205,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
         run: |
@@ -220,6 +227,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -244,6 +252,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -328,6 +337,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -356,6 +366,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -382,6 +393,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           submodules: true
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
@@ -413,6 +425,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - uses: ./.github/actions/checkout-trace-format
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/checkout-trace-format
-      - uses: dtolnay/rust-toolchain@1.83.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - run: >-
           cargo check
@@ -135,6 +135,12 @@ jobs:
         with:
           submodules: true
       - uses: ./.github/actions/checkout-trace-format
+      - name: Add macOS POSIX tools
+        if: runner.os == 'macOS'
+        run: |
+          echo "$(nix build --no-link --print-out-paths nixpkgs#coreutils)/bin" >> "$GITHUB_PATH"
+          echo "$(nix build --no-link --print-out-paths nixpkgs#gnugrep)/bin" >> "$GITHUB_PATH"
+          echo "$(nix build --no-link --print-out-paths nixpkgs#gnused)/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   check:
     name: Build
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@stable
@@ -78,7 +78,7 @@ jobs:
 
   test-asan:
     name: Test (Address Sanitizer)
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -104,7 +104,7 @@ jobs:
 
   min-version:
     name: Check mininum supported Rust version
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.83.0
@@ -121,7 +121,7 @@ jobs:
       matrix:
         include:
           - os: linux
-            runner: [self-hosted, nixos]
+            runner: ubuntu-24.04
           - os: windows
             runner: [self-hosted, Windows, X64, nixos-equivalent]
           - os: macos
@@ -153,7 +153,7 @@ jobs:
 
   fmt:
     name: Formatting
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@master
@@ -172,7 +172,7 @@ jobs:
 
   doc:
     name: Documentation
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@stable
@@ -196,7 +196,7 @@ jobs:
 
   audit:
     name: Audit
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dtolnay/rust-toolchain@stable
@@ -215,7 +215,7 @@ jobs:
 
   udeps:
     name: uDeps
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -236,7 +236,7 @@ jobs:
 
   fuzz:
     name: Fuzz
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         fuzz_target: ['translate', 'execute', 'differential']
@@ -323,7 +323,7 @@ jobs:
 
   miri:
     name: Miri
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -351,7 +351,7 @@ jobs:
 
   miri-spec:
     name: Miri (spec)
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -377,7 +377,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
@@ -403,7 +403,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: [self-hosted, nixos]
+    runs-on: ubuntu-24.04
     container:
       image: xd009642/tarpaulin:develop-nightly
       options: --security-opt seccomp=unconfined

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,15 +1660,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -2806,12 +2812,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd-sys"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -49,8 +49,7 @@ fn main() -> Result<()> {
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("<wasm>");
-    let mut recorder =
-        maybe_open_recorder(program_name, args.trace_out(), args.trace_format())?;
+    let mut recorder = maybe_open_recorder(program_name, args.trace_out(), args.trace_format())?;
 
     // If the recorder is enabled, stage the CLI-provided argv slice as
     // canonical CTFS call args (`arg0..argN-1`) and open the top-level

--- a/crates/cli/src/recorder.rs
+++ b/crates/cli/src/recorder.rs
@@ -7,16 +7,16 @@
 //!
 //! Audit scope (this iteration — see AUDIT-CTFS-2026-05.md):
 //!   * Default-Ctfs CLI scaffold via `--trace-out` + `--trace-format` (a).
-//!   * Top-level [`wasmi::Func::call`] boundary as a [`register_call`]
+//!   * Top-level [`wasmi::Func::call`] boundary as a `register_call`
 //!     site (b).
 //!   * Wasmi function-signature `&[Val]` parameters staged via
-//!     [`TraceWriter::arg`] as `arg{i}`-named call-args (c).
+//!     `TraceWriter::arg` as `arg{i}`-named call-args (c).
 //!   * `wasmi::Error` (host trap, validation error, OOG, ...) routed through
-//!     [`register_special_event`] with `EventLogKind::Error` and metadata
+//!     `register_special_event` with `EventLogKind::Error` and metadata
 //!     `wasmi_trap` (d / i).
 //!
 //! Out of scope (deferred to follow-up audits):
-//!   * Per-instruction / per-source-line [`register_step`] from the wasmi
+//!   * Per-instruction / per-source-line `register_step` from the wasmi
 //!     interpreter loop.  Closing this needs a hook in the executor's
 //!     instruction-dispatch loop (`crates/wasmi/src/engine/executor/`).
 //!   * Intra-program function-call boundaries (`call` / `call_indirect`
@@ -24,7 +24,7 @@
 //!   * DWARF-driven argument names (currently we use positional `arg0..argN`
 //!     placeholders, mirroring Miden 1.56 stack[0..3] -> s0..s3).
 //!   * WASI host-fn output capture (`fd_write`, `fd_read`) routed through
-//!     [`register_special_event`] with `EventLogKind::Write` /
+//!     `register_special_event` with `EventLogKind::Write` /
 //!     `EventLogKind::Read`.
 //!   * Wasm threads proposal (wasmi does not currently support it).
 
@@ -241,7 +241,7 @@ impl WasmiRecorder {
     }
 
     /// Decode a wasmi [`Val`] into a [`ValueRecord`] suitable for
-    /// [`TraceWriter::register_return`].
+    /// `TraceWriter::register_return`.
     ///
     /// `register_return` does not carry a typed parameter slot, so we use
     /// the value-only conversion here (vs. the param-typed path used by
@@ -366,10 +366,11 @@ fn wasmi_val_to_value_record_inner(
 /// rather than clap's default `binary-v0` kebab-case, mirroring the
 /// PolkaVM 1.55 / Miden 1.56 / TON 1.57 sibling CLI surfaces that all
 /// use snake_case for their format identifiers.
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 #[clap(rename_all = "snake_case")]
 pub enum CliTraceFormat {
     /// Canonical CodeTracer multi-stream container (recommended).
+    #[default]
     Ctfs,
     /// Legacy CBOR + Zstd binary format.
     Binary,
@@ -377,12 +378,6 @@ pub enum CliTraceFormat {
     BinaryV0,
     /// Human-readable JSON (slower; useful for debugging).
     Json,
-}
-
-impl Default for CliTraceFormat {
-    fn default() -> Self {
-        CliTraceFormat::Ctfs
-    }
 }
 
 impl From<CliTraceFormat> for TraceEventsFileFormat {

--- a/crates/cli/src/recorder.rs
+++ b/crates/cli/src/recorder.rs
@@ -32,10 +32,18 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Error as AnyhowError, Result};
 use codetracer_trace_types::{
-    EventLogKind, Line, TypeKind, TypeRecord, TypeSpecificInfo, ValueRecord, NONE_VALUE,
+    EventLogKind,
+    Line,
+    TypeKind,
+    TypeRecord,
+    TypeSpecificInfo,
+    ValueRecord,
+    NONE_VALUE,
 };
 use codetracer_trace_writer_nim::{
-    create_trace_writer, TraceEventsFileFormat, TraceWriter as TraceWriterTrait,
+    create_trace_writer,
+    TraceEventsFileFormat,
+    TraceWriter as TraceWriterTrait,
 };
 use wasmi::{Error as WasmiError, FuncType, Val};
 
@@ -109,7 +117,11 @@ impl WasmiRecorder {
 
         // Open the trace at the synthetic top-level location.  Mirrors
         // PolkaVM 1.55 step-7.
-        TraceWriterTrait::start(&mut *writer, Path::new(WASMI_VIRTUAL_PATH), WASMI_VIRTUAL_LINE);
+        TraceWriterTrait::start(
+            &mut *writer,
+            Path::new(WASMI_VIRTUAL_PATH),
+            WASMI_VIRTUAL_LINE,
+        );
 
         Ok(Self { writer, out_dir })
     }
@@ -130,8 +142,7 @@ impl WasmiRecorder {
         // / Miden 1.56 / TON 1.57 sibling recorders all chain `close()`
         // after `finish_writing_trace_events` + `write_meta_dat`; we
         // mirror that ordering here.
-        TraceWriterTrait::close(&mut *self.writer)
-            .map_err(|e| anyhow!("close: {e}"))?;
+        TraceWriterTrait::close(&mut *self.writer).map_err(|e| anyhow!("close: {e}"))?;
         Ok(())
     }
 
@@ -151,12 +162,7 @@ impl WasmiRecorder {
     /// support lands (out of scope for this audit), the names will be
     /// upgraded by reading `DW_TAG_formal_parameter` ranges keyed on the
     /// wasm function index.
-    pub fn register_top_level_call(
-        &mut self,
-        func_name: &str,
-        func_ty: &FuncType,
-        args: &[Val],
-    ) {
+    pub fn register_top_level_call(&mut self, func_name: &str, func_ty: &FuncType, args: &[Val]) {
         // Make sure the function-id is known to the writer.  We treat the
         // entry-point as `<func_name> @ <virtual> : 1` because wasmi has not
         // resolved the actual `.wasm` module's source path yet.  Empty


### PR DESCRIPTION
## Summary
- wire recorder CI Nix setup through the Attic substituter variables
- keep the existing workflow shape and only pass cache configuration into setup-dev-env/setup-nix
- remove raw Cachix Nix setup where this repo still had it

## Validation
- parsed modified workflow YAML with yq
- ran a workflow audit confirming non-windows setup-dev-env calls pass vars.SUBSTITUTERS and vars.TRUSTED_PUBLIC_KEYS
- ran a workflow audit confirming no active owned-Cachix setup/upload references remain
